### PR TITLE
fix: resolve SSR hydration mismatch in ScanHistory component

### DIFF
--- a/src/components/ScanHistory.tsx
+++ b/src/components/ScanHistory.tsx
@@ -99,22 +99,26 @@ export const ScanHistory = memo(function ScanHistory({
   }, [tab, availableTabs]);
 
   // Shuffle examples once on mount so Whirlpool variants don't cluster together
-  const [shuffledExamples] = useState(() => {
+  // Use effect to avoid hydration mismatch from Math.random() during SSR
+  const [shuffledExamples, setShuffledExamples] = useState(examples);
+  const [showAllExamples, setShowAllExamples] = useState(false);
+  // Responsive: 2 on very small screens (<400px), 3 on mobile, 4 on desktop
+  const [previewCount, setPreviewCount] = useState(4);
+
+  useEffect(() => {
+    // Shuffle after mount to avoid hydration mismatch
     const arr = [...examples];
     for (let i = arr.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [arr[i], arr[j]] = [arr[j], arr[i]];
     }
-    return arr;
-  });
-  const [showAllExamples, setShowAllExamples] = useState(false);
-  // Responsive: 2 on very small screens (<400px), 3 on mobile, 4 on desktop
-  const [previewCount] = useState(() => {
-    if (typeof window === "undefined") return 4;
-    if (window.innerWidth < 400) return 2;
-    if (window.innerWidth < 640) return 3;
-    return 4;
-  });
+    setShuffledExamples(arr);
+
+    // Set responsive preview count after mount
+    if (window.innerWidth < 400) setPreviewCount(2);
+    else if (window.innerWidth < 640) setPreviewCount(3);
+    else setPreviewCount(4);
+  }, [examples]);
 
   return (
     <motion.div


### PR DESCRIPTION
## Summary

- Fixed React hydration mismatch warning in `ScanHistory` component caused by non-deterministic values during SSR
- Moved `Math.random()` shuffle and `window.innerWidth` check from `useState` initializers to `useEffect` to ensure consistent server/client rendering

## Context

This project uses `output: "export"` (static site generation), so there's no SSR in production - the hydration mismatch only occurs during development. This fix is primarily a **DX improvement** to eliminate console warnings during `pnpm dev`.

## Problem

The component was causing hydration warnings in dev because:

1. **`Math.random()` in `useState` initializer** - The examples shuffle produced different order on server vs client
2. **`typeof window === "undefined"` check in `useState`** - Server returned `4` while client returned `2/3` depending on screen width

```
Hydration failed because the server rendered text didn't match the client.
- Server: "OP_RETURN data"  
- Client: "Satoshi's address"
```

## Solution

Moved both the shuffle logic and responsive `previewCount` calculation into a `useEffect` hook, so they only execute after hydration on the client. The initial render now uses stable values (original `examples` order and `previewCount=4`) that match between server and client.

## Test plan

- [x] Page loads without hydration warnings in dev
- [x] Examples are shuffled after mount
- [x] Responsive preview count works correctly
- [x] No impact on production build (static export)