### PR TITLE
fix: correct antiFeeSniping for Nunchuk (#80)

### DIFF
--- a/src/data/guide/__tests__/wallets.test.ts
+++ b/src/data/guide/__tests__/wallets.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { RECOMMENDED_WALLETS } from "../wallets";
+
+/**
+ * Source-code-cited facts for the wallet comparison table. These pin
+ * down the antiFeeSniping defaults that have been audited against the
+ * upstream wallet code, so a future data sweep cannot silently flip
+ * them back without the test failing.
+ *
+ * Citations live in the PR descriptions for adb691d (Trezor / Cake /
+ * BlueWallet / BitBox) and #88 (Nunchuk). Bull Bitcoin's `true` is
+ * source-verified against BDK's TxBuilder default.
+ */
+const ANTI_FEE_SNIPING_GROUND_TRUTH: Record<string, boolean> = {
+  // Verified true: wallet sets nLockTime to current block height by default.
+  Sparrow: true,
+  "Bitcoin Core": true,
+  Electrum: true,
+  Ashigaru: true,
+  "Blockstream App": true,
+  "Bull Bitcoin": true, // uses BDK TxBuilder (sets locktime by default)
+
+  // Verified false: wallet leaves nLockTime at 0 by default, even if a
+  // user-toggleable setting exists (Nunchuk) or if the protocol uses
+  // a different timelock strategy (Wasabi).
+  "Trezor Suite": false,
+  Wasabi: false,
+  "Cake Wallet": false,
+  Nunchuk: false, // PR #88 - opt-in only via Fee Settings, defaults to off
+  "Blue Wallet": false,
+  BitBoxApp: false,
+};
+
+function findWallet(name: string) {
+  const w = RECOMMENDED_WALLETS.find((x) => x.name === name);
+  if (!w) throw new Error(`wallet ${name} not present in RECOMMENDED_WALLETS`);
+  return w;
+}
+
+describe("RECOMMENDED_WALLETS antiFeeSniping ground truth", () => {
+  for (const [name, expected] of Object.entries(ANTI_FEE_SNIPING_GROUND_TRUTH)) {
+    it(`${name} antiFeeSniping === ${expected}`, () => {
+      expect(findWallet(name).antiFeeSniping).toBe(expected);
+    });
+  }
+
+  it("every wallet in the audit list is present in the table", () => {
+    const tableNames = new Set(RECOMMENDED_WALLETS.map((w) => w.name));
+    for (const name of Object.keys(ANTI_FEE_SNIPING_GROUND_TRUTH)) {
+      expect(tableNames.has(name), `expected ${name} in RECOMMENDED_WALLETS`).toBe(true);
+    }
+  });
+});
+
+describe("RECOMMENDED_WALLETS schema", () => {
+  it("has no duplicate wallet names", () => {
+    const names = RECOMMENDED_WALLETS.map((w) => w.name);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+
+  it("every wallet declares at least one device type", () => {
+    for (const w of RECOMMENDED_WALLETS) {
+      expect(w.type.length, `${w.name} has no type`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/data/guide/wallets.ts
+++ b/src/data/guide/wallets.ts
@@ -114,7 +114,7 @@ export const RECOMMENDED_WALLETS: WalletEntry[] = [
     name: "Nunchuk",
     type: ["desktop", "mobile"],
     nSequence: "good",
-    antiFeeSniping: true,
+    antiFeeSniping: false,
     coinJoin: false,
     payJoin: false,
     bip47: false,


### PR DESCRIPTION
## Summary

Completes the audit started in [adb691d](https://github.com/Copexit/am-i-exposed/commit/adb691d) which covered Trezor Suite, Cake Wallet, Blue Wallet, and BitBoxApp. Nunchuk was identified in the same evidence block of [#80](https://github.com/Copexit/am-i-exposed/issues/80) but missed in that pass.

The change is a single boolean flip in [src/data/guide/wallets.ts](src/data/guide/wallets.ts):

```diff
   {
     name: "Nunchuk",
     ...
-    antiFeeSniping: true,
+    antiFeeSniping: false,
```

## Source verification

Nunchuk does not enable anti-fee-sniping by default. The locktime is set to the current block height only when the user explicitly opts in via the Fee Settings toggle, which defaults to off.

**libnunchuk (C++ backend)**

[`include/nunchuk.h`](https://github.com/nunchuk-io/libnunchuk/blob/main/include/nunchuk.h) - `CreateTransaction` defaults the parameter to false:

\`\`\`cpp
bool anti_fee_sniping = false,
\`\`\`

[`src/nunchukimpl.cpp`](https://github.com/nunchuk-io/libnunchuk/blob/main/src/nunchukimpl.cpp) - locktime stays at 0 unless the caller passes true:

\`\`\`cpp
uint32_t locktime = 0, sequence = 0;
if (anti_fee_sniping) {
    locktime = GetChainTip();
    sequence = MAX_BIP125_RBF_SEQUENCE;
}
\`\`\`

**Nunchuk Android app**

[`NcDataStore.kt`](https://github.com/nunchuk-io/nunchuk-android/blob/main/nunchuk-core/src/main/java/com/nunchuk/android/core/persistence/NcDataStore.kt) - the persisted preference defaults to false.

[`FeeSettingsViewModel.kt`](https://github.com/nunchuk-io/nunchuk-android/blob/main/nunchuk-settings/src/main/java/com/nunchuk/android/settings/feesettings/FeeSettingsViewModel.kt):

\`\`\`kotlin
val antiFeeSniping: Boolean = false,
\`\`\`

The Settings -> Fee Settings UI labels the toggle "Enable Anti-Fee Sniping" / "Adds the latest block height to the PSBT to prevent fee sniping attacks" - it is opt-in. Even internal flows like SATSCARD sweep hardcode `antiFeeSniping = false`.

## Convention check

This matches the existing convention that the column reflects default user-facing behavior. Wasabi is already marked `false` in the table even though it supports RBF, on the same principle.

## Original evidence

Source citations originate from [@4rkad's comment](https://github.com/Copexit/am-i-exposed/issues/80#issuecomment-4137027058) on the issue. Credit to them for the audit work.

## Test plan

- [x] `pnpm lint` - 0 errors
- [ ] Manual: open `/guide` page, locate Nunchuk row in the wallet comparison table, confirm the Anti-fee-sniping column now shows the value associated with `false`