### PR TITLE
fix: i18n the entity-origin recommendation detail (#84)

### DIFF
--- a/src/components/PrimaryRecommendation.tsx
+++ b/src/components/PrimaryRecommendation.tsx
@@ -54,10 +54,10 @@ function RecCard({ rec }: { rec: PrimaryRec }) {
             </span>
           </div>
           <h3 className="text-base font-semibold text-foreground mt-1.5 leading-snug">
-            {t(rec.headlineKey, { defaultValue: rec.headlineDefault })}
+            {t(rec.headlineKey, { defaultValue: rec.headlineDefault, ...rec.tParams })}
           </h3>
           <p className="text-sm text-muted mt-1 leading-relaxed">
-            {t(rec.detailKey, { defaultValue: rec.detailDefault })}
+            {t(rec.detailKey, { defaultValue: rec.detailDefault, ...rec.tParams })}
           </p>
           <div className="flex items-center gap-3 mt-2 flex-wrap">
             {rec.tools && rec.tools.map((tool) => (

--- a/src/lib/recommendations/__tests__/primary-recommendation.test.ts
+++ b/src/lib/recommendations/__tests__/primary-recommendation.test.ts
@@ -422,6 +422,69 @@ describe("Cascade priority - higher tier wins", () => {
   });
 });
 
+// ── Entity origin (pre-tier check) ──────────────────────────────────
+
+describe("Entity origin (pre-tier check)", () => {
+  it("exchange category selects the .exchange detail key", () => {
+    const [primary] = selectRecommendations({
+      findings: [],
+      grade: "C",
+      walletGuess: null,
+      entityOrigin: "Coinbase",
+      entityCategory: "exchange",
+    });
+    expect(primary.id).toBe("rec-entity-origin");
+    expect(primary.detailKey).toBe("primaryRec.entityOrigin.detail.exchange");
+    expect(primary.tParams?.entity).toBe("Coinbase");
+  });
+
+  it("payment category selects the .exchange detail key", () => {
+    const [primary] = selectRecommendations({
+      findings: [],
+      grade: "C",
+      walletGuess: null,
+      entityOrigin: "BitPay",
+      entityCategory: "payment",
+    });
+    expect(primary.detailKey).toBe("primaryRec.entityOrigin.detail.exchange");
+  });
+
+  it("non-exchange category selects the .other detail key", () => {
+    const [primary] = selectRecommendations({
+      findings: [],
+      grade: "C",
+      walletGuess: null,
+      entityOrigin: "Reddit",
+      entityCategory: "merchant",
+    });
+    expect(primary.detailKey).toBe("primaryRec.entityOrigin.detail.other");
+    expect(primary.tParams?.entity).toBe("Reddit");
+  });
+
+  it("headline carries the entity interpolation parameter", () => {
+    const [primary] = selectRecommendations({
+      findings: [],
+      grade: "C",
+      walletGuess: null,
+      entityOrigin: "Kraken",
+      entityCategory: "exchange",
+    });
+    expect(primary.headlineKey).toBe("primaryRec.entityOrigin.headline");
+    expect(primary.headlineDefault).toContain("{{entity}}");
+  });
+
+  it("CoinJoin presence suppresses the entity-origin recommendation", () => {
+    const [primary] = selectRecommendations({
+      findings: [cjFinding()],
+      grade: "B",
+      walletGuess: null,
+      entityOrigin: "Coinbase",
+      entityCategory: "exchange",
+    });
+    expect(primary.id).not.toBe("rec-entity-origin");
+  });
+});
+
 // ── Every recommendation has required fields ────────────────────────
 
 describe("All recommendations have required fields", () => {
@@ -439,6 +502,8 @@ describe("All recommendations have required fields", () => {
     ["change-single", ctx([f("h2-change-detected", { params: { corroboratorCount: 1 } })])],
     ["low-entropy", ctx([f("h5-low-entropy", { scoreImpact: -3 })])],
     ["round-amount", ctx([f("h1-round-amount")])],
+    ["entity-origin-exchange", { findings: [], grade: "C", walletGuess: null, entityOrigin: "Coinbase", entityCategory: "exchange" }],
+    ["entity-origin-other", { findings: [], grade: "C", walletGuess: null, entityOrigin: "Reddit", entityCategory: "merchant" }],
     ["a-plus-cj", ctx([cjFinding()], "A+")],
     ["a-plus", ctx([], "A+")],
     ["b-grade", ctx([], "B")],

--- a/src/lib/recommendations/primary-recommendation.ts
+++ b/src/lib/recommendations/primary-recommendation.ts
@@ -20,6 +20,8 @@ export interface PrimaryRec {
   tool?: { name: string; url: string };
   tools?: { name: string; url: string }[];
   guideLink?: string;
+  /** Interpolation values passed to react-i18next t() for headline and detail. */
+  tParams?: Record<string, string | number>;
 }
 
 export interface RecommendationContext {

--- a/src/lib/recommendations/recommendation-tiers.ts
+++ b/src/lib/recommendations/recommendation-tiers.ts
@@ -41,26 +41,24 @@ export function pickTool(
   }
 }
 
-export function buildEntityDetail(
-  entityName: string,
-  entityCategory: string | null | undefined,
-  isExchange: boolean,
-): string {
-  if (isExchange) {
-    return (
-      `This transaction was constructed by ${entityName}. Privacy recommendations for transaction ` +
-      "construction do not apply - you did not choose the inputs, outputs, or structure. " +
-      "To protect your privacy after receiving these funds: keep them in a separate wallet from " +
-      "non-KYC coins, consider CoinJoin before spending, and avoid consolidating with other UTXOs."
-    );
-  }
-  return (
-    `This transaction was constructed by ${entityName} (${entityCategory ?? "known entity"}). ` +
+/**
+ * English fallback strings for the entity-origin recommendation detail.
+ * Mirrors primaryRec.entityOrigin.detail.{exchange,other} in the locale
+ * files. Used as react-i18next `defaultValue` when the translation key
+ * cannot be resolved. {{entity}} is interpolated via PrimaryRec.tParams.
+ */
+const ENTITY_DETAIL_DEFAULTS = {
+  exchange:
+    "This transaction was constructed by {{entity}}. Privacy recommendations for transaction " +
+    "construction do not apply - you did not choose the inputs, outputs, or structure. " +
+    "To protect your privacy after receiving these funds: keep them in a separate wallet from " +
+    "non-KYC coins, consider CoinJoin before spending, and avoid consolidating with other UTXOs.",
+  other:
+    "This transaction was constructed by {{entity}}. " +
     "Privacy recommendations for transaction construction do not apply. " +
     "To reduce exposure: spend received UTXOs individually, use CoinJoin to break the trail, " +
-    "and avoid linking these funds to your other addresses."
-  );
-}
+    "and avoid linking these funds to your other addresses.",
+} as const;
 
 // ── Shared context for tier checks ───────────────────────────────────
 
@@ -83,16 +81,17 @@ export function checkEntityOrigin(tc: TierContext): TierResult {
 
   if (entityOrigin && !hasCoinJoin) {
     const isExchange = ctx.entityCategory === "exchange" || ctx.entityCategory === "payment";
-    const detail = buildEntityDetail(entityOrigin, ctx.entityCategory, isExchange);
+    const variant = isExchange ? "exchange" : "other";
 
     return [
       {
         id: "rec-entity-origin",
         urgency: "when-convenient",
         headlineKey: "primaryRec.entityOrigin.headline",
-        headlineDefault: `Transaction constructed by ${entityOrigin}`,
-        detailKey: "primaryRec.entityOrigin.detail",
-        detailDefault: detail,
+        headlineDefault: "Transaction constructed by {{entity}}",
+        detailKey: `primaryRec.entityOrigin.detail.${variant}`,
+        detailDefault: ENTITY_DETAIL_DEFAULTS[variant],
+        tParams: { entity: entityOrigin },
         guideLink: "/guide#coin-control",
       },
       null,


### PR DESCRIPTION
## Summary

The primary recommendation for transactions constructed by a known entity (exchange withdrawals, etc.) rendered in English regardless of the active locale because [`checkEntityOrigin`](src/lib/recommendations/recommendation-tiers.ts) set `detailKey` to the non-existent key `primaryRec.entityOrigin.detail` instead of the variant-specific keys that already exist in all six locales.

Repro from [#84](https://github.com/Copexit/am-i-exposed/issues/84): set locale to Spanish, scan [`87ce47f5...`](https://mempool.space/tx/87ce47f5fafc55435b858dadc70bfc91644c57cba6d2c6c9a088925509369222), observe the recommendation detail in English.

## What changed

Three files, additive:

| File | Change |
|------|--------|
| [`src/lib/recommendations/primary-recommendation.ts`](src/lib/recommendations/primary-recommendation.ts) | Add optional `tParams?: Record<string, string \| number>` to `PrimaryRec` so interpolation values can travel with a recommendation. |
| [`src/lib/recommendations/recommendation-tiers.ts`](src/lib/recommendations/recommendation-tiers.ts) | `checkEntityOrigin` now selects `primaryRec.entityOrigin.detail.exchange` (for `exchange`/`payment` categories) or `primaryRec.entityOrigin.detail.other` otherwise, and passes `tParams: { entity: entityOrigin }`. Replaces `buildEntityDetail()` with static `ENTITY_DETAIL_DEFAULTS` so the English fallback mirrors the locale strings exactly. |
| [`src/components/PrimaryRecommendation.tsx`](src/components/PrimaryRecommendation.tsx) | Spread `rec.tParams` into both `t()` calls so `{{entity}}` interpolates whether the result comes from the locale or the `defaultValue` fallback. |

## Why a side-quest on `buildEntityDetail`

The previous helper injected `entityCategory` into the non-exchange string (\"...constructed by Reddit (merchant)...\"). The locale files do not. So the English text differed from the translated text in *content*, not just language. Removing it makes English a faithful fallback for the locale, which is what react-i18next assumes.

## Tests

Added five focused tests in [`primary-recommendation.test.ts`](src/lib/recommendations/__tests__/primary-recommendation.test.ts) covering:

 - `exchange` category routes to `detail.exchange`
 - `payment` category also routes to `detail.exchange`
 - other categories route to `detail.other`
 - headline default carries `{{entity}}` placeholder
 - CoinJoin presence still suppresses the entity-origin recommendation

Also extended the parametrized \"All recommendations have required fields\" check with `entity-origin-exchange` and `entity-origin-other` scenarios.

## Test plan

- [x] `pnpm lint` - 0 errors
- [x] `pnpm test src/lib/recommendations/__tests__/primary-recommendation.test.ts` - 71 passed
- [x] `pnpm build` - clean static export
- [ ] Manual: set locale to es/fr/de/pt/pl, scan a tx with an entity-origin (e.g. [`87ce47f5...`](https://mempool.space/tx/87ce47f5fafc55435b858dadc70bfc91644c57cba6d2c6c9a088925509369222)), verify the recommendation detail renders in the active locale with the entity name interpolated.

## Notes

`buildEntityDetail` is removed (it was not imported anywhere else in the codebase). If any external consumer needs it back, the replacement is `ENTITY_DETAIL_DEFAULTS[isExchange ? \"exchange\" : \"other\"]`.