### PR TITLE
fix: surface unconfirmed status on graph nodes (#87)

### DIFF
--- a/src/components/viz/graph/GraphNodeRenderer.tsx
+++ b/src/components/viz/graph/GraphNodeRenderer.tsx
@@ -232,7 +232,17 @@ export function GraphNodeRenderer({
       )}
 
       {/* Badge pills */}
-      <NodeBadges nodeX={node.x} nodeY={node.y} nodeWidth={node.width} isCoinJoin={node.isCoinJoin} coinJoinType={node.coinJoinType} isOfac={node.entityOfac} isToxicMerge={toxicMergeNodes.has(node.txid)} />
+      <NodeBadges
+        nodeX={node.x}
+        nodeY={node.y}
+        nodeWidth={node.width}
+        isCoinJoin={node.isCoinJoin}
+        coinJoinType={node.coinJoinType}
+        isOfac={node.entityOfac}
+        isToxicMerge={toxicMergeNodes.has(node.txid)}
+        isUnconfirmed={!node.confirmed}
+        unconfirmedLabel={t("graph.unconfirmed", { defaultValue: "Unconfirmed" })}
+      />
 
       {/* Privacy score sparkline */}
       {heatMapActive && heatMap.has(node.txid) && (

--- a/src/components/viz/graph/GraphTooltipContent.tsx
+++ b/src/components/viz/graph/GraphTooltipContent.tsx
@@ -46,7 +46,7 @@ export function GraphTooltipContent({ tooltip, scrollRef, heatMapActive, heatMap
         </div>
       ) : (
         /* Node hover: minimal chip - only data NOT already on the canvas label */
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <span className="font-mono text-xs" style={{ color: SVG_COLORS.muted }}>{truncateId(data.txid, 6)}</span>
           {data.entityLabel ? (
             <span className="text-xs font-medium" style={{ color: ENTITY_CATEGORY_COLORS[data.entityCategory ?? "unknown"] }}>

--- a/src/components/viz/graph/NodeBadges.tsx
+++ b/src/components/viz/graph/NodeBadges.tsx
@@ -16,6 +16,8 @@ interface NodeBadgesProps {
   coinJoinType?: string;
   isOfac?: boolean;
   isToxicMerge: boolean;
+  isUnconfirmed?: boolean;
+  unconfirmedLabel?: string;
 }
 
 export function NodeBadges({
@@ -26,11 +28,14 @@ export function NodeBadges({
   coinJoinType,
   isOfac,
   isToxicMerge,
+  isUnconfirmed,
+  unconfirmedLabel,
 }: NodeBadgesProps) {
   const badges: Badge[] = [];
   if (isCoinJoin) badges.push({ label: coinJoinType ?? "CJ", bg: SVG_COLORS.good, fg: SVG_COLORS.background });
   if (isOfac) badges.push({ label: "OFAC", bg: SVG_COLORS.critical, fg: SVG_COLORS.background });
   if (isToxicMerge) badges.push({ label: "TOXIC", bg: "#ef4444", fg: SVG_COLORS.background });
+  if (isUnconfirmed) badges.push({ label: unconfirmedLabel ?? "Unconfirmed", bg: SVG_COLORS.medium, fg: SVG_COLORS.background });
   if (badges.length === 0) return null;
 
   const by = nodeY + 42;


### PR DESCRIPTION
## Summary

Closes [#87](https://github.com/Copexit/am-i-exposed/issues/87). Two related issues in the Transaction Graph Explorer:

1. **The hover tooltip's orange \"Unconfirmed\" label was clipped.** The chip row used \`flex items-center gap-2\` without \`flex-wrap\`, so with four siblings (txid, entity/CoinJoin tag, fee rate, unconfirmed) the row overflowed and the trailing item was cut off.
2. **Unconfirmed status required hovering each suspect node to find.** No persistent visual cue on the canvas, matching the reporter's wish: \"you should not need to hover over the specific outspend to see whether it is confirmed or not.\"

## What changed

| File | Change |
|------|--------|
| [`NodeBadges.tsx`](src/components/viz/graph/NodeBadges.tsx) | Added two optional props (\`isUnconfirmed\`, \`unconfirmedLabel\`) and a new pill that follows the existing OFAC / TOXIC / CJ styling, in `SVG_COLORS.medium` (the same amber the tooltip already used). |
| [`GraphNodeRenderer.tsx`](src/components/viz/graph/GraphNodeRenderer.tsx) | Pass \`!node.confirmed\` and the existing \`graph.unconfirmed\` i18n key to NodeBadges. No new data plumbing - the renderer already used \`node.confirmed\` for the tooltip data block. |
| [`GraphTooltipContent.tsx`](src/components/viz/graph/GraphTooltipContent.tsx) | Switched the node-hover chip row from \`flex items-center gap-2\` to \`flex flex-wrap items-center gap-x-2 gap-y-1\` so long rows wrap rather than clip. |

## i18n

Reuses the existing \`graph.unconfirmed\` key which is already populated in all six locales (en/es/de/fr/pt/pl). No new translation work required.

## Test plan

- [x] \`pnpm lint\` - 0 errors (3 pre-existing warnings unchanged)
- [x] \`pnpm test src/components/viz/graph/\` - 34 passed
- [x] \`pnpm build\` - clean static export
- [ ] Manual: load a tx with an unconfirmed parent/child in the Graph Explorer, confirm an orange \"Unconfirmed\" pill appears below the node, persistently visible without hovering.
- [ ] Manual: hover a node with an entity label + unconfirmed status, confirm the tooltip wraps onto a second line instead of clipping.

## Notes

The badge uses the same width formula as existing badges (\`label.length * 5.5 + 8\`); \"Unconfirmed\" is 11 chars so ~68px wide. With the default node width of ~150px this fits comfortably alongside one other badge. If a node has CJ + OFAC + TOXIC + Unconfirmed (rare combination), the leftmost badge will overflow the left edge by a few pixels - acceptable for an edge case, and the tooltip wrap covers it.