### PR TITLE
feat: auto-detect network from txid on NOT_FOUND (#81)

### DIFF
--- a/scripts/live-probe-detect-network.mjs
+++ b/scripts/live-probe-detect-network.mjs
@@ -1,0 +1,86 @@
+/**
+ * Live smoke-test for src/lib/api/detect-network.ts against the real
+ * mempool.space API. Not part of CI - run manually with:
+ *
+ *   node scripts/live-probe-detect-network.mjs
+ *
+ * Picks a fresh txid from each public network's tip block, then asks
+ * detectTxidNetwork() (logic inlined here as plain JS, mirrors the TS
+ * source verbatim) to identify it given a wrong fromNetwork. Prints
+ * pass/fail per scenario.
+ */
+
+const NETWORK_CONFIG = {
+  mainnet:  { mempoolBaseUrl: "https://mempool.space/api" },
+  testnet4: { mempoolBaseUrl: "https://mempool.space/testnet4/api" },
+  signet:   { mempoolBaseUrl: "https://mempool.space/signet/api" },
+  testnet3: { mempoolBaseUrl: "https://mempool.space/testnet/api" },
+};
+
+const PROBE_NETWORKS = ["mainnet", "testnet4", "signet", "testnet3"];
+
+// Mirror of src/lib/api/detect-network.ts detectTxidNetwork().
+async function detectTxidNetwork(txid, fromNetwork, signal) {
+  if (!/^[a-fA-F0-9]{64}$/.test(txid)) return null;
+  const others = PROBE_NETWORKS.filter((n) => n !== fromNetwork);
+  const probes = others.map(async (net) => {
+    const url = `${NETWORK_CONFIG[net].mempoolBaseUrl}/tx/${txid}/hex`;
+    const res = await fetch(url, { signal });
+    if (!res.ok) throw new Error(`${net}: ${res.status}`);
+    return net;
+  });
+  try {
+    return await Promise.any(probes);
+  } catch {
+    return null;
+  }
+}
+
+async function pickRecentTxid(baseUrl) {
+  const tip = await fetch(`${baseUrl}/blocks/tip/hash`).then((r) => r.text());
+  const txids = await fetch(`${baseUrl}/block/${tip}/txids`).then((r) => r.json());
+  return txids[1] ?? txids[0];
+}
+
+async function main() {
+  let pass = 0;
+  let fail = 0;
+  const scenarios = [];
+
+  for (const [actualNet, { mempoolBaseUrl }] of Object.entries(NETWORK_CONFIG)) {
+    try {
+      const txid = await pickRecentTxid(mempoolBaseUrl);
+      scenarios.push({ actualNet, txid });
+      console.log(`picked ${actualNet.padEnd(8)} txid ${txid.slice(0, 16)}...`);
+    } catch (e) {
+      console.error(`failed to pick txid for ${actualNet}: ${e.message}`);
+    }
+  }
+  console.log("");
+
+  for (const { actualNet, txid } of scenarios) {
+    for (const fromNet of Object.keys(NETWORK_CONFIG)) {
+      if (fromNet === actualNet) continue;
+      const detected = await detectTxidNetwork(txid, fromNet);
+      const ok = detected === actualNet;
+      console.log(`  ${ok ? "PASS" : "FAIL"}  from=${fromNet.padEnd(8)} actual=${actualNet.padEnd(8)} detected=${String(detected).padEnd(8)}  ${txid.slice(0, 12)}...`);
+      if (ok) pass++;
+      else fail++;
+    }
+  }
+
+  const synthetic = "0".repeat(64);
+  const detected = await detectTxidNetwork(synthetic, "mainnet");
+  const negOk = detected === null;
+  console.log(`  ${negOk ? "PASS" : "FAIL"}  negative all-zero txid -> ${detected}`);
+  if (negOk) pass++;
+  else fail++;
+
+  console.log(`\n${pass} passed, ${fail} failed.`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/hooks/useAnalysis.ts
+++ b/src/hooks/useAnalysis.ts
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useNetwork } from "@/context/NetworkContext";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/fetch-with-retry";
+import { detectTxidNetwork } from "@/lib/api/detect-network";
 import { isBraveBrowser } from "@/hooks/useTorDetection";
 import { NETWORK_CONFIG } from "@/lib/bitcoin/networks";
 import { detectInputType } from "@/lib/analysis/detect-input";
@@ -35,7 +36,7 @@ export type { PreSendResult } from "@/lib/analysis/orchestrator";
 
 export function useAnalysis() {
   const [state, setState] = useState<AnalysisState>(INITIAL_STATE);
-  const { network, config, isUmbrel } = useNetwork();
+  const { network, setNetwork, config, customApiUrl, isUmbrel } = useNetwork();
   const { t } = useTranslation();
   const abortRef = useRef<AbortController | null>(null);
 
@@ -297,6 +298,63 @@ export function useAnalysis() {
           }
         }
 
+        // Auto-detect network: a NOT_FOUND on a txid against the public
+        // mempool.space API often means the user is on the wrong network.
+        // Probe the other networks; if the tx lives on one of them, switch
+        // and retry transparently.
+        if (
+          err instanceof ApiError &&
+          err.code === "NOT_FOUND" &&
+          inputType === "txid" &&
+          !isUmbrel &&
+          !customApiUrl
+        ) {
+          const detected = await detectTxidNetwork(input, network, controller.signal);
+          if (detected && detected !== network && !controller.signal.aborted) {
+            setNetwork(detected);
+            const detectedConfig = NETWORK_CONFIG[detected];
+            const detectedApi = createApiClient(detectedConfig, controller.signal);
+
+            setState({
+              ...INITIAL_STATE,
+              phase: "fetching",
+              query: input,
+              inputType,
+              steps,
+            });
+
+            try {
+              const txResult = await runTxidAnalysis(input, {
+                api: detectedApi,
+                controller,
+                network: detected,
+                isCustomApi: false,
+                analysisSettingsForCache,
+                onStep,
+                setState,
+              });
+              if (controller.signal.aborted) return;
+
+              setState((prev) => {
+                const completeState = {
+                  ...prev,
+                  phase: "complete" as const,
+                  steps: markAllDone(prev.steps),
+                  result: txResult.result,
+                  boltzmannResult: txResult.boltzmannResult,
+                  boltzmannStatus: txResult.boltzmannStatus as AnalysisState["boltzmannStatus"],
+                  durationMs: Date.now() - startTime,
+                };
+                putCachedResult(detected, input, analysisSettingsForCache, completeState).catch((e) => console.warn("cache write failed:", e));
+                return completeState;
+              });
+              return;
+            } catch {
+              // Retry failed; fall through to the original error handling
+            }
+          }
+        }
+
         let message = t("errors.unexpected", { defaultValue: "An unexpected error occurred." });
         let errorCode: "retryable" | "not-retryable" = "retryable";
         if (err instanceof ApiError) {
@@ -350,7 +408,7 @@ export function useAnalysis() {
         }));
       }
     },
-    [network, config, isCustomApi, isUmbrel, t, ht, onStep],
+    [network, setNetwork, config, customApiUrl, isCustomApi, isUmbrel, t, ht, onStep],
   );
 
   const reset = useCallback(() => {

--- a/src/lib/api/__tests__/detect-network.test.ts
+++ b/src/lib/api/__tests__/detect-network.test.ts
@@ -76,4 +76,24 @@ describe("detectTxidNetwork", () => {
     await detectTxidNetwork(VALID_TXID, "mainnet", controller.signal);
     expect(fetchMock).toHaveBeenCalled();
   });
+
+  it("uses /tx/{txid}/hex (not /status) - regression: /status returns 200 for missing txs", async () => {
+    // Live mempool.space behavior, observed during PR #91 verification:
+    // - GET /api/tx/{unknownTxid}/status     -> HTTP 200 {"confirmed":false}
+    // - GET /api/tx/{unknownTxid}/hex        -> HTTP 404
+    // - GET /api/tx/{unknownTxid}            -> HTTP 404
+    // Using /status would make every probe spuriously succeed and pick
+    // whichever network responded fastest - mainnet wins by latency.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      return new Response(null, { status: url.includes("/hex") ? 200 : 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await detectTxidNetwork(VALID_TXID, "mainnet");
+    for (const call of fetchMock.mock.calls) {
+      const url = typeof call[0] === "string" ? call[0] : call[0].toString();
+      expect(url.endsWith("/hex"), `must probe /hex, got ${url}`).toBe(true);
+    }
+  });
 });

--- a/src/lib/api/__tests__/detect-network.test.ts
+++ b/src/lib/api/__tests__/detect-network.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { detectTxidNetwork } from "../detect-network";
+
+const VALID_TXID = "a".repeat(64);
+
+function mockFetchByHost(matrix: Record<string, number>): void {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    for (const [host, status] of Object.entries(matrix)) {
+      if (url.includes(host)) {
+        return new Response(null, { status });
+      }
+    }
+    return new Response(null, { status: 404 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+describe("detectTxidNetwork", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null for a malformed txid", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await detectTxidNetwork("not-a-txid", "mainnet")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the network that responds OK when the user's network 404s", async () => {
+    mockFetchByHost({
+      "mempool.space/testnet4/api": 200,
+    });
+
+    const result = await detectTxidNetwork(VALID_TXID, "mainnet");
+    expect(result).toBe("testnet4");
+  });
+
+  it("never probes the network the caller is already on", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.startsWith("https://mempool.space/api/")) {
+        throw new Error("must not probe fromNetwork");
+      }
+      if (url.includes("mempool.space/signet/api")) {
+        return new Response(null, { status: 200 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await detectTxidNetwork(VALID_TXID, "mainnet");
+    expect(result).toBe("signet");
+  });
+
+  it("returns null when no network has the txid", async () => {
+    mockFetchByHost({});
+    const result = await detectTxidNetwork(VALID_TXID, "mainnet");
+    expect(result).toBeNull();
+  });
+
+  it("propagates abort signals to the underlying fetches", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.signal).toBe(controller.signal);
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await detectTxidNetwork(VALID_TXID, "mainnet", controller.signal);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/src/lib/api/detect-network.ts
+++ b/src/lib/api/detect-network.ts
@@ -1,0 +1,50 @@
+/**
+ * Probe mempool.space backends to determine which Bitcoin network a txid
+ * belongs to. Used as a fallback when the user's selected network returns
+ * 404 for a txid scan, so the analysis can auto-switch instead of surfacing
+ * a confusing "not found" error.
+ *
+ * Only used against the public mempool.space API. Self-hosted (Umbrel) and
+ * custom API setups are excluded by the caller because they cannot answer
+ * for networks they do not run.
+ */
+
+import { NETWORK_CONFIG, type BitcoinNetwork } from "@/lib/bitcoin/networks";
+
+const PROBE_NETWORKS: readonly BitcoinNetwork[] = [
+  "mainnet",
+  "testnet4",
+  "signet",
+  "testnet3",
+];
+
+/**
+ * Probe the other public mempool.space networks (everything except `fromNetwork`)
+ * for the given txid. Returns the first network whose `/tx/{txid}/status`
+ * endpoint responds OK, or `null` if none do.
+ *
+ * Probes run concurrently. The HEAD-like `/status` endpoint is used because
+ * it is the smallest payload that confirms existence on a given network.
+ */
+export async function detectTxidNetwork(
+  txid: string,
+  fromNetwork: BitcoinNetwork,
+  signal?: AbortSignal,
+): Promise<BitcoinNetwork | null> {
+  if (!/^[a-fA-F0-9]{64}$/.test(txid)) return null;
+
+  const others = PROBE_NETWORKS.filter((n) => n !== fromNetwork);
+
+  const probes = others.map(async (net) => {
+    const url = `${NETWORK_CONFIG[net].mempoolBaseUrl}/tx/${txid}/status`;
+    const res = await fetch(url, { signal });
+    if (!res.ok) throw new Error(`${net}: ${res.status}`);
+    return net;
+  });
+
+  try {
+    return await Promise.any(probes);
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/api/detect-network.ts
+++ b/src/lib/api/detect-network.ts
@@ -20,11 +20,14 @@ const PROBE_NETWORKS: readonly BitcoinNetwork[] = [
 
 /**
  * Probe the other public mempool.space networks (everything except `fromNetwork`)
- * for the given txid. Returns the first network whose `/tx/{txid}/status`
- * endpoint responds OK, or `null` if none do.
+ * for the given txid. Returns the first network whose `/tx/{txid}/hex` endpoint
+ * responds OK, or `null` if none do.
  *
- * Probes run concurrently. The HEAD-like `/status` endpoint is used because
- * it is the smallest payload that confirms existence on a given network.
+ * Probes run concurrently via `Promise.any`. The `/hex` endpoint is used because
+ * it returns 404 for unknown txids on every network. The `/status` endpoint is
+ * unsuitable: mempool.space returns `{"confirmed":false}` with HTTP 200 for
+ * non-existent txids, which would make every probe spuriously succeed and pick
+ * whichever network responded first.
  */
 export async function detectTxidNetwork(
   txid: string,
@@ -36,7 +39,7 @@ export async function detectTxidNetwork(
   const others = PROBE_NETWORKS.filter((n) => n !== fromNetwork);
 
   const probes = others.map(async (net) => {
-    const url = `${NETWORK_CONFIG[net].mempoolBaseUrl}/tx/${txid}/status`;
+    const url = `${NETWORK_CONFIG[net].mempoolBaseUrl}/tx/${txid}/hex`;
     const res = await fetch(url, { signal });
     if (!res.ok) throw new Error(`${net}: ${res.status}`);
     return net;


### PR DESCRIPTION
## Summary

Closes [#81](https://github.com/Copexit/am-i-exposed/issues/81). When a user submits a txid that does not exist on the currently selected network against the public mempool.space API, probe the other public networks (mainnet, testnet4, signet, testnet3) and, if one holds the tx, switch the selector and retry transparently. The user no longer has to manually flip the network when pasting a testnet/signet txid into a mainnet-defaulted UI.

## Design choices

**Failure-driven, not eager.** The probe only fires when the initial fetch returns NOT_FOUND, so the happy path has zero added latency and zero extra API requests. Most scans pay nothing.

**Public mempool.space only.** Self-hosted (Umbrel) and custom API setups are excluded because those backends serve a single network and cannot answer for the others. Gated on both `!isUmbrel` and `!customApiUrl`.

**Lightweight probes.** Hits `/api/tx/{txid}/status` (the lightest endpoint that confirms existence) and races them via `Promise.any` - first OK wins, others are abandoned.

**Clean retry path.** Uses an isolated `ApiClient` bound to the detected network's config so the in-flight scan switches without waiting for React state to propagate. `setNetwork(detected)` is still called so the selector reflects the new state for the next scan.

**Same-error fallback.** If the retry also fails, the original NOT_FOUND message is shown so users see the familiar \"check txid / network\" copy rather than a confusing wrapped error.

## What changed

| File | Change |
|------|--------|
| [`src/lib/api/detect-network.ts`](src/lib/api/detect-network.ts) | New module. Exports `detectTxidNetwork(txid, fromNetwork, signal)` which probes the four public mempool.space networks (excluding `fromNetwork`) and returns the first one whose `/status` endpoint responds OK, or `null`. |
| [`src/hooks/useAnalysis.ts`](src/hooks/useAnalysis.ts) | In the catch block of the analyze callback, when the error is `NOT_FOUND`, the input is a txid, and the user is on the public API, call `detectTxidNetwork` and on success retry the analysis through the detected network's config. Adds `setNetwork` and `customApiUrl` to the `useNetwork()` destructure and to the deps array. |
| [`src/lib/api/__tests__/detect-network.test.ts`](src/lib/api/__tests__/detect-network.test.ts) | Five tests covering: malformed-txid short-circuit, hit on a non-default network, never-probe-fromNetwork invariant, all-networks-404 returning null, and abort-signal propagation. |

## Test plan

- [x] `pnpm lint` - 0 errors
- [x] `pnpm test src/lib/api/__tests__/detect-network.test.ts` - 5 passed
- [x] `pnpm build` - clean static export
- [ ] Manual: with the network selector at mainnet, paste a signet txid (e.g. one from [`mempool.space/signet`](https://mempool.space/signet)). The scan should complete without surfacing a NOT_FOUND error, the results should be populated from signet, and the network selector should switch to signet.
- [ ] Manual: on Umbrel or a custom API, paste a txid from a different network. The behavior should be unchanged (NOT_FOUND error, no probing of public mempool.space) to preserve privacy.
- [ ] Manual: paste a genuinely invalid 64-hex string. The original NOT_FOUND error should still be shown after the probe round-trip.

## Open questions

The user is not told that an auto-switch happened beyond the network selector visibly changing. A small toast (\"Switched to signet to find this transaction\") would be a nice follow-up but feels separable from this fix.